### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 cache: pip
 dist: bionic
@@ -9,6 +12,12 @@ python:
     - '3.8'
     - pypy2
     - pypy3
+matrix:
+   exclude:
+      - python: pypy2
+        arch: ppc64le
+      - python: pypy3
+        arch: ppc64le
 install:
     - pip install codecov tox
 script:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/javaproperties/builds/191878059 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!